### PR TITLE
Allow a custom name formatter for test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ The output file specifies where the trx file will be written.
 The trx reporter will attend the browser name to the test name by default.
 This can be switched off with the shortTestName config property.
 
+### nameFormatter
+You can provide a custom function to format the `testName` field of the trx.
+The `nameFormatter` is a function with parameters `(browser, result)` which returns a string.
+When `nameFormatter` is provided, `shortTestName` is ignored.
+
 You can pass list of reporters as a CLI argument too:
 ```bash
 karma start --reporters trx,dots

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This can be switched off with the shortTestName config property.
 ### nameFormatter
 You can provide a custom function to format the `testName` field of the trx.
 The `nameFormatter` is a function with parameters `(browser, result)` which returns a string.
-When `nameFormatter` is provided, `shortTestName` is ignored.
+When `shortTestName` is `true``, `nameFormatter` is ignored.
 
 You can pass list of reporters as a CLI argument too:
 ```bash

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This can be switched off with the shortTestName config property.
 ### nameFormatter
 You can provide a custom function to format the `testName` field of the trx.
 The `nameFormatter` is a function with parameters `(browser, result)` which returns a string.
-When `shortTestName` is `true``, `nameFormatter` is ignored.
+When `shortTestName` is `true`, `nameFormatter` is ignored.
 
 You can pass list of reporters as a CLI argument too:
 ```bash

--- a/index.js
+++ b/index.js
@@ -2,10 +2,15 @@ var path = require('path');
 var fs = require('fs');
 var builder = require('xmlbuilder');
 
+function defaultNameFormatter (browser, result) {
+    return browser.name + '_' + result.description;
+}
+
 var TRXReporter = function (baseReporterDecorator, config, emitter, logger, helper, formatError) {
     var outputFile = config.outputFile;
     var shortTestName = !!config.shortTestName;
     var trimTimestamps = !!config.trimTimestamps;
+    var nameFormatter = config.nameFormatter || defaultNameFormatter;
     var log = logger.create('reporter.trx');
     var hostName = require('os').hostname();
     var testRun;
@@ -131,9 +136,9 @@ var TRXReporter = function (baseReporterDecorator, config, emitter, logger, help
 
     this.specSuccess = this.specSkipped = this.specFailure = function (browser, result) {
         var unitTestId = newGuid();
-        var unitTestName = shortTestName
-            ? result.description
-            : browser.name + '_' + result.description;
+        var unitTestName = shortTestName 
+            ? result.description 
+            : nameFormatter(browser, result);
         var className = result.suite.join('.');
         var codeBase = className + '.' + unitTestName;
 


### PR DESCRIPTION
Similar to karma-junit-reporter, allow the karma.conf.js to provide a custom formatting function for the test name. If the formatter is not provided, the name formatting will remain unchanged.

Update docs to describe this new option.